### PR TITLE
fix(database): fixed helm templating with disabled postgresql

### DIFF
--- a/charts/matrix/templates/deployment.yaml
+++ b/charts/matrix/templates/deployment.yaml
@@ -103,6 +103,7 @@ spec:
               os.umask(0o077)
               with open("/tmp/synapse.yaml", "w") as fp:
                   yaml.dump(config, fp)
+          {{- if .Values.postgresql.enabled }}
           env:
             - name: PG_USER
               value: "{{ include "postgresql.v1.username" .Subcharts.postgresql }}"
@@ -110,6 +111,7 @@ spec:
               value: "{{ include "postgresql.v1.database" .Subcharts.postgresql }}"
             - name: PG_HOST
               value: "{{ include "postgresql.v1.primary.fullname" .Subcharts.postgresql }}"
+          {{- end }}
           ports:
             - name: http
               containerPort: 8008


### PR DESCRIPTION
The postgresql credentials in the deployment env vars are read / included via a template helper defined in the bitnami postgresql subchart.

If this is disabled, Helm is still trying to template the env vars, and fails with the following message:
`error: Error: template: matrix/templates/deployment.yaml:112:25: executing "matrix/templates/deployment.yaml" at <include "postgres.fullname" .Subcharts.postgres>: error calling include: template: no template "postgres.fullname" associated with template "gotpl"`

This Pull Request adds a conditional check and only sets the postgresql env vars when postgresql is actually enabled.

Fixes #3 