### PR TITLE
Support PVC hostPath

### DIFF
--- a/charts/matrix/templates/persistentvolumeclaim.yaml
+++ b/charts/matrix/templates/persistentvolumeclaim.yaml
@@ -19,5 +19,5 @@ spec:
   {{- if ne .Values.storage.hostPath nil }}
   hostPath:
     path: {{ .Values.storage.hostPath }}
-  {{- if ne .Values.storage.hostPath nil }}
+  {{- end }}
 {{- end }}

--- a/charts/matrix/templates/persistentvolumeclaim.yaml
+++ b/charts/matrix/templates/persistentvolumeclaim.yaml
@@ -16,4 +16,8 @@ spec:
   resources:
     requests:
       storage: {{ .Values.storage.capacity }}
+  {{- if ne .Values.storage.hostPath nil }}
+  hostPath:
+    path: {{ .Values.storage.hostPath }}
+  {{- if ne .Values.storage.hostPath nil }}
 {{- end }}


### PR DESCRIPTION
This is useful for mounting the volume to a specific path on the host runner.