### PR TITLE
fix(synapse): fixed image  version due to broken Synapse release

### DIFF
--- a/charts/matrix/Chart.yaml
+++ b/charts/matrix/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 version: 2.3.4
 
 # The version of Synapse
-appVersion: "1.121.0"
+appVersion: "1.121.1"
 
 dependencies:
   - name: postgresql


### PR DESCRIPTION
This PR updates the Synapse version to 1.121.1

1.121.0 can't be pulled from Docker, seems that there was an issue during release: https://github.com/element-hq/synapse/releases/tag/v1.121.1