### PR TITLE
docs: update ref to synapse docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,4 +63,4 @@ element:
     host: element.example.org
 ```
 
-For a list of the settings allowed in `homeserverConfig`, check out [Synapse's own documentation](https://matrix-org.github.io/synapse/latest/usage/configuration/config_documentation.html).
+For a list of the settings allowed in `homeserverConfig`, check out [Synapse's own documentation](https://element-hq.github.io/synapse/latest/usage/configuration/config_documentation.html).

--- a/charts/matrix/values.yaml
+++ b/charts/matrix/values.yaml
@@ -18,7 +18,7 @@ additionalLabels: {}
 homeserverConfig:
   # For more information on how to configure Synapse, including a complete accounting of
   # each option, go to docs/usage/configuration/config_documentation.md or
-  # https://matrix-org.github.io/synapse/latest/usage/configuration/config_documentation.html
+  # https://element-hq.github.io/synapse/latest/usage/configuration/config_documentation.html
 
   # This should point to your domain
   server_name: "example.org"


### PR DESCRIPTION
This pull request updates the link from the README to the updated URL of the upstream application repo.

The current link shows the following message in a warning modal at the top of the page:

> ### This documentation may be out of date!
> 
> This documentation site is for the versions of Synapse maintained by the Matrix.org Foundation ([github.com/matrix-org/synapse](https://github.com/matrix-org/synapse)), available under the Apache 2.0 licence.

> 
> Since version 1.99, Synapse is now maintained by Element under a new licence ([github.com/element-hq/synapse](https://github.com/element-hq/synapse)).

> 
> If you are interested in the documentation for a later version of Synapse, please [click here to navigate to this same page on the latest Element Synapse documentation site](https://element-hq.github.io/synapse/latest/usage/configuration/config_documentation.html), if it's available.
