### PR TITLE
Use Implementation specific for /.well-known directory

### DIFF
--- a/charts/matrix/templates/ingress.yaml
+++ b/charts/matrix/templates/ingress.yaml
@@ -71,7 +71,7 @@ spec:
               {{- end }}
           - path: /.well-known
             {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
-            pathType: Prefix
+            pathType: ImplementationSpecific
             {{- end }}
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}


### PR DESCRIPTION
With Prefix only alpha numeric is supported, in this case we might want ImplementationSpecific. Without it, you can not install the release