### PR TITLE
Decreased ingress path scope to avoid collisions and added documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,4 +63,19 @@ element:
     host: element.example.org
 ```
 
+Synapse can directly be hosted on your domain (e.g. `example.org`) as well. It just exposes `/_matrix`, `/_synapse` and optionally `/.well-known/matrix`.
+If Synapse is hosted on a subdomain (e.g. `synapse.example.org`) and you want to use federation via `.well-known`, make sure `/.well-known/matrix` is available on your root domain (e.g. `example.org`) - for example by deploying an additional Ingress.
+
 For a list of the settings allowed in `homeserverConfig`, check out [Synapse's own documentation](https://element-hq.github.io/synapse/latest/usage/configuration/config_documentation.html).
+
+## Troubleshooting
+
+### path /.well-known/matrix cannot be used with pathType Prefix
+
+If you use DNS records for federation, you can set `ingress.expose_well_known` to `false`.
+Otherwise you need to relax to ingress-nginx controller validation by setting `controller.config.strict-validate-path-type` to `"false"`.
+See: https://github.com/kubernetes/ingress-nginx/issues/11176
+
+### matrix-federation://matrix.org/\_matrix/federation/...: HttpResponseException('401: Unauthorized')
+
+You need to advertise your Matrix server via DNS SRV record or `.well-known` path on your root domain (see notes above).

--- a/charts/matrix/templates/ingress.yaml
+++ b/charts/matrix/templates/ingress.yaml
@@ -70,7 +70,8 @@ spec:
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
               {{- end }}
-          - path: /.well-known
+          {{- if .Values.ingress.expose_well_known -}}
+          - path: /.well-known/matrix
             {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
             pathType: {{ $pathType }}
             {{- end }}
@@ -84,5 +85,6 @@ spec:
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
               {{- end }}
+          {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/matrix/values.yaml
+++ b/charts/matrix/values.yaml
@@ -133,6 +133,7 @@ service:
 
 ingress:
   enabled: false
+  expose_well_known: true
   className: ""
   pathType: Prefix
   annotations: {}


### PR DESCRIPTION
## Issue

- The `.well-known` path in the Ingress may collide with other Ingresses trying to route `.well-known`
- The `.well-known` path fails the validation of `ingress-nginx`, because it contains a dot
- The `.well-known` path needs to be exposed on the root domain to be effective

## Changes

- Made the `.well-known` path more specific to avoid collisions
- Made the `.well-known` path optional, in case a subdomain or DNS entries are used
- Added troubleshooting section to the README for common pitfalls

## Considerations

- Since the `.well-known` path does not work out of the box when using a subdomain, an option to deploy an additional Ingress for it on the root domain would be nice. I did not include this here to limit the scope of the PR.