### PR TITLE
Publish charts as OCI to ghcr.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,18 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v3
 
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.5.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Push charts to GitHub Container Registry
+        run: |
+          find .cr-release-packages -type f -print0 | xargs -t -0 -r -I{} helm push {} oci://ghcr.io/${{ github.repository }}

--- a/charts/matrix/Chart.yaml
+++ b/charts/matrix/Chart.yaml
@@ -16,5 +16,5 @@ dependencies:
     condition: postgresql.enabled
   - name: element
     version: ">=1.1.0,<1.3.0"
-    repository: https://remram44.github.io/matrix-helm
+    repository: oci://ghcr.io/remram44/matrix-helm/charts
     condition: element.enabled


### PR DESCRIPTION
Fixes #26

Probably should wait for the next release to test this.